### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -20,6 +20,8 @@ const clone = (toObj, fromObj) => {
     for (let keyIdx = 0; keyIdx < fromObjKeys.length; keyIdx++) {
       const fromObjKey = fromObjKeys[keyIdx];
 
+      if (isPrototypePolluted(fromObjKey)) continue;
+
       if (toObj[fromObjKey] && fromObj[fromObjKey] // both of them has values
         && typeof toObj[fromObjKey] === 'object' && typeof fromObj[fromObjKey] === 'object' // both of them type object
         && ((toObj[fromObjKey].constructor === Object && fromObj[fromObjKey].constructor === Object) // both of them really Object
@@ -33,5 +35,7 @@ const clone = (toObj, fromObj) => {
 
   return toObj;
 };
+
+const isPrototypePolluted = (key) => ['__proto__', 'constructor', 'prototype'].includes(key);
 
 module.exports = clone;


### PR DESCRIPTION
### :bar_chart: Metadata *

`deep-merger` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-deep-merger

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var deepMerger = require("deep-merger")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
deepMerger.immutateDeepMerge(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i deep-merger # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/102754650-4746ae00-4393-11eb-9655-376a7cf777c8.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
